### PR TITLE
Fix import for contribution and add dep for dependency management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 ical-cache
 .idea
 .vs
+/vendor
+ical-tvshows
+Gopkg.lock

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,0 +1,7 @@
+[[constraint]]
+  name = "gopkg.in/redis.v4"
+  version = "4.2.4"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/taviti/caldav-go"

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ If you choose to use Redis as a cache you must set the connection parameters.
 
 ## Contribution
 
-This project use [dep](https://github.com/golang/dep) to manage its dependencies.
+This project uses [dep](https://github.com/golang/dep) to manage its dependencies.
 So if you want to contribute, do the following:
 - Install go in its latest version (1.9.2)
-- Install dep in its latest verion (0.3.2)
-- git clone the project in your `$GOPATH/src/github.com/adrientoub/`
+- Install dep in its latest version (0.3.2)
+- `git clone` the project in your `$GOPATH/src/github.com/adrientoub/`
 - execute `dep ensure` at the project root in your favorite terminal
 - you should now be able to `go build` as you want

--- a/README.md
+++ b/README.md
@@ -34,3 +34,13 @@ contain the following informations:
 
 In the config, the "cache" key can be any of: "redis", "files" or "none".
 If you choose to use Redis as a cache you must set the connection parameters.
+
+## Contribution
+
+This project use [dep](https://github.com/golang/dep) to manage its dependencies.
+So if you want to contribute, do the following:
+- Install go in its latest version (1.9.2)
+- Install dep in its latest verion (0.3.2)
+- git clone the project in your `$GOPATH/src/github.com/adrientoub/`
+- execute `dep ensure` at the project root in your favorite terminal
+- you should now be able to `go build` as you want

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -3,7 +3,7 @@ package cache
 import (
 	"log"
 
-	"../config"
+	"github.com/adrientoub/ical-tvshows/config"
 )
 
 type Cache int

--- a/cache/redis.go
+++ b/cache/redis.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/adrientoub/ical-tvshows/config"
+
 	"gopkg.in/redis.v4"
 )
 

--- a/main.go
+++ b/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"log"
 
-	"./config"
-	"./server"
+	"github.com/adrientoub/ical-tvshows/config"
+	"github.com/adrientoub/ical-tvshows/server"
 )
 
 func main() {

--- a/server/generate_calendar.go
+++ b/server/generate_calendar.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"net/http"
 
-	"../cache"
+	"github.com/adrientoub/ical-tvshows/cache"
 )
 
 const url = "https://calendar.google.com/calendar/ical/td5o0neuo68pb2ush6bun9inu8%40group.calendar.google.com/public/basic.ics"

--- a/server/show_list.go
+++ b/server/show_list.go
@@ -10,8 +10,8 @@ import (
 	"regexp"
 	"strings"
 
-	"../cache"
-	"../config"
+	"github.com/adrientoub/ical-tvshows/cache"
+	"github.com/adrientoub/ical-tvshows/config"
 )
 
 const apiBase = "https://api.betaseries.com/"


### PR DESCRIPTION
Relative import are not recommended on Golang especially in the case of an open-source project on Github.
This fix the `go get` error that appeared since the last commit